### PR TITLE
Proxy fixes to issues related to proxying REGISTERs and INVITEs that are challenged

### DIFF
--- a/src/drachtio.cpp
+++ b/src/drachtio.cpp
@@ -197,6 +197,14 @@ namespace drachtio {
 		return false ;
 	}
 
+    void makeUniqueSipTransactionIdentifier(sip_t* sip, string& str) {
+        str = sip->sip_call_id->i_id ;
+        str.append("|") ;
+        str.append(sip->sip_cseq->cs_method_name) ;
+        str.append("|") ;
+        str.append( boost::lexical_cast<std::string>(sip->sip_cseq->cs_seq) ) ;
+    }
+
 	void generateUuid(string& uuid) {
 #ifdef BOOST_UUID
 	    boost::uuids::uuid id = boost::uuids::random_generator()();

--- a/src/drachtio.h
+++ b/src/drachtio.h
@@ -91,6 +91,8 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(severity, "Severity", severity_levels) ;
 		,uas_role
 	}; 
 
+  void makeUniqueSipTransactionIdentifier(sip_t* sip, string& str) ;
+
 	void generateUuid(std::string& uuid) ;
 
 	void parseGenericHeader( msg_common_t* p, std::string& hvalue) ;

--- a/src/pending-request-controller.hpp
+++ b/src/pending-request-controller.hpp
@@ -55,6 +55,12 @@ namespace drachtio {
     sip_t* getSipObject() ;
     const string& getCallId() ;
     const string& getTransactionId() ;
+    void getUniqueSipTransactionIdentifier(string& str) { 
+      sip_t* sip = sip_object(m_msg) ;
+      makeUniqueSipTransactionIdentifier(sip, str);
+    }
+    const string& getMethodName() ;
+    uint32_t getCSeq() ;
     tport_t* getTport() ;
     TimerEventHandle getTimerHandle(void) { return m_handle;}
     void setTimerHandle( TimerEventHandle handle ) { m_handle = handle;}
@@ -63,6 +69,8 @@ namespace drachtio {
     msg_t*  m_msg ;
     string  m_transactionId ;
     string  m_callId ;
+    uint32_t m_seq ;
+    string m_methodName ;
     tport_t* m_tp ;
     TimerEventHandle m_handle ;
   } ;
@@ -80,8 +88,10 @@ namespace drachtio {
     void logStorageCount(void) ;
 
     bool isRetransmission( sip_t* sip ) {
+      string id ;
+      makeUniqueSipTransactionIdentifier( sip, id ) ;
       boost::lock_guard<boost::mutex> lock(m_mutex) ;
-      mapCallId2Invite::iterator it = m_mapCallId2Invite.find( sip->sip_call_id->i_id ) ;   
+      mapCallId2Invite::iterator it = m_mapCallId2Invite.find( id ) ;   
       return it != m_mapCallId2Invite.end() ;
     }
 

--- a/src/sip-proxy-controller.cpp
+++ b/src/sip-proxy-controller.cpp
@@ -440,8 +440,11 @@ namespace drachtio {
             sip_add_tl(msg, sip, SIPTAG_MAX_FORWARDS_STR("70"), TAG_END());
         }
 
-        sip_request_t *rq = sip_request_format(msg_home(msg), "%s %s SIP/2.0", sip->sip_request->rq_method_name, m_target.c_str() ) ;
-        msg_header_replace(msg, NULL, (msg_header_t *)sip->sip_request, (msg_header_t *) rq) ;
+        //only replace request uri if it is a local address
+        if( isLocalSipUri( m_target ) ) {
+            sip_request_t *rq = sip_request_format(msg_home(msg), "%s %s SIP/2.0", sip->sip_request->rq_method_name, m_target.c_str() ) ;
+            msg_header_replace(msg, NULL, (msg_header_t *)sip->sip_request, (msg_header_t *) rq) ;
+        }
 
         tagi_t* tags = makeTags( headers ) ;
 

--- a/src/sip-proxy-controller.cpp
+++ b/src/sip-proxy-controller.cpp
@@ -1141,7 +1141,7 @@ namespace drachtio {
             nta_msg_tsend( nta, msg, NULL, TAG_END() ) ;  
             return true ;                      
         }
-        boost::shared_ptr<ProxyCore> p = getProxyByCallId( sip->sip_call_id->i_id ) ;
+        boost::shared_ptr<ProxyCore> p = getProxy( sip ) ;
 
         if( !p ) return false ;
 
@@ -1169,7 +1169,7 @@ namespace drachtio {
         }
 
         if( sip_method_prack == sip->sip_request->rq_method ) {
-            boost::shared_ptr<ProxyCore> p = getProxyByCallId( sip->sip_call_id->i_id ) ;
+            boost::shared_ptr<ProxyCore> p = getProxy( sip ) ;
             if( !p ) {
                DR_LOG(log_error) << "SipProxyController::processRequestWithRouteHeader unknown call-id for PRACK " <<  
                     sip->sip_call_id->i_id ;
@@ -1198,7 +1198,7 @@ namespace drachtio {
     bool SipProxyController::processRequestWithoutRouteHeader( msg_t* msg, sip_t* sip ) {
         string callId = sip->sip_call_id->i_id ;
 
-        boost::shared_ptr<ProxyCore> p = getProxyByCallId( sip->sip_call_id->i_id ) ;
+        boost::shared_ptr<ProxyCore> p = getProxy( sip ) ;
         if( !p ) {
             DR_LOG(log_error) << "SipProxyController::processRequestWithoutRouteHeader unknown call-id for " <<  sip->sip_request->rq_method_name << " " << callId;
             nta_msg_discard( nta, msg ) ;
@@ -1251,15 +1251,19 @@ namespace drachtio {
         return true ;
     }
     bool SipProxyController::isProxyingRequest( msg_t* msg, sip_t* sip )  {
+      string id ;
+      makeUniqueSipTransactionIdentifier(sip, id) ;
       boost::lock_guard<boost::mutex> lock(m_mutex) ;
-      mapCallId2Proxy::iterator it = m_mapCallId2Proxy.find( sip->sip_call_id->i_id ) ;
+      mapCallId2Proxy::iterator it = m_mapCallId2Proxy.find( id ) ;
       return it != m_mapCallId2Proxy.end() ;
     }
 
-    boost::shared_ptr<ProxyCore> SipProxyController::removeProxyByCallId( const string& callId ) {
+    boost::shared_ptr<ProxyCore> SipProxyController::removeProxy( sip_t* sip ) {
+      string id ;
+      makeUniqueSipTransactionIdentifier(sip, id); 
       boost::shared_ptr<ProxyCore> p ;
       boost::lock_guard<boost::mutex> lock(m_mutex) ;
-      mapCallId2Proxy::iterator it = m_mapCallId2Proxy.find( callId ) ;
+      mapCallId2Proxy::iterator it = m_mapCallId2Proxy.find( id ) ;
       if( it != m_mapCallId2Proxy.end() ) {
         p = it->second ;
         m_mapCallId2Proxy.erase(it) ;
@@ -1268,7 +1272,7 @@ namespace drachtio {
       return p ;
     }
     void SipProxyController::removeProxy( boost::shared_ptr<ProxyCore> pCore ) {
-        removeProxyByCallId( sip_object( pCore->msg() )->sip_call_id->i_id ) ;
+        removeProxy( sip_object( pCore->msg() ) ) ;
     }
 
     bool SipProxyController::isTerminatingResponse( int status ) {
@@ -1287,8 +1291,11 @@ namespace drachtio {
         bool simultaneous, const string& provisionalTimeout, const string& finalTimeout, vector<string> vecDestination, 
         const string& headers ) {
 
-      DR_LOG(log_debug) << "SipProxyController::addProxy - adding transaction id " << transactionId << ", call-id " << 
-        sip->sip_call_id->i_id << " before insert there are "<< m_mapCallId2Proxy.size() << " proxy instances";
+      string id ;
+      makeUniqueSipTransactionIdentifier(sip, id) ;
+
+      DR_LOG(log_debug) << "SipProxyController::addProxy - adding transaction id " << transactionId << ", id " << 
+        id << " before insert there are "<< m_mapCallId2Proxy.size() << " proxy instances";
 
       boost::shared_ptr<ProxyCore> p = boost::make_shared<ProxyCore>( clientMsgId, transactionId, tp, recordRoute, 
         fullResponse, simultaneous, headers ) ;
@@ -1297,7 +1304,7 @@ namespace drachtio {
       if( !provisionalTimeout.empty() ) p->setProvisionalTimeout( provisionalTimeout ) ;
       
       boost::lock_guard<boost::mutex> lock(m_mutex) ;
-      m_mapCallId2Proxy.insert( mapCallId2Proxy::value_type(sip->sip_call_id->i_id, p) ) ;
+      m_mapCallId2Proxy.insert( mapCallId2Proxy::value_type(id, p) ) ;
       return p ;         
     }
     void SipProxyController::logStorageCount(void)  {


### PR DESCRIPTION
Previously the proxy core tracked unique transactions by call-id alone.  This led to a situation where when a REGISTER got challenged and the client reissued a new request with the same call-id but an incremented CSeq value the proxy would incorrectly discard it as a retransmission.  The proxy core has been modified to track transactions by the combination of call-id + method + cseq value