### PR TITLE
Don't replace request-uri if it is a tel uri.

### DIFF
--- a/src/sip-proxy-controller.cpp
+++ b/src/sip-proxy-controller.cpp
@@ -533,16 +533,20 @@ namespace drachtio {
             throw std::runtime_error("ProxyCore::ClientTransaction::forwardRequest: TODO: need to implement support for app providing no destination (proxy to ruri)") ;
         }
 
-        // check if the original request-uri was a local address -- if so, replace it with the provided destination
-        string originalUri = sip->sip_request->rq_url->url_scheme ;
-        originalUri.append(":");
-        originalUri.append(sip->sip_request->rq_url->url_host) ;
+        // don't replace request-uri if it is a tel uri
+        if ( 0 != strcmp( sip->sip_request->rq_url->url_scheme, "tel" )) {
+            // check if the original request-uri was a local address -- if so, replace it with the provided destination
+            string originalUri = sip->sip_request->rq_url->url_scheme ;
 
-        //only replace request uri if it is a local address
-        if( isLocalSipUri( originalUri ) ) {
-            DR_LOG(log_debug) << "ProxyCore::ClientTransaction::forwardRequest - replacing request uri because incoming request uri is local: " << originalUri ;
-            sip_request_t *rq = sip_request_format(msg_home(msg), "%s %s SIP/2.0", sip->sip_request->rq_method_name, m_target.c_str() ) ;
-            msg_header_replace(msg, NULL, (msg_header_t *)sip->sip_request, (msg_header_t *) rq) ;
+            originalUri.append(":");
+            originalUri.append(sip->sip_request->rq_url->url_host) ;
+
+            // only replace request-uri if it is a local address
+            if( isLocalSipUri( originalUri ) ) {
+                DR_LOG(log_debug) << "ProxyCore::ClientTransaction::forwardRequest - replacing request uri because incoming request uri is local: " << originalUri ;
+                sip_request_t *rq = sip_request_format(msg_home(msg), "%s %s SIP/2.0", sip->sip_request->rq_method_name, m_target.c_str() ) ;
+                msg_header_replace(msg, NULL, (msg_header_t *)sip->sip_request, (msg_header_t *) rq) ;
+            }
         }
 
         string record_route, transport ;


### PR DESCRIPTION
In the case where the Request-Line contains a tel URI, such as "INVITE tel:+14085550002 SIP/2.0", skip the code that might replace the local address with destination host address, which isn't part of a tel URI.