### PR TITLE
Dockerfile config copy issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,13 @@ RUN apt-get update \
   && rm -Rf /var/log/* \
   && rm -Rf /var/lib/apt/lists/* \
   && cd /usr/local/src \
+  && cp drachtio-server/docker.drachtio.conf.xml /etc/drachtio.conf.xml \
   && rm -Rf drachtio-server \
   && cd /usr/local/bin \
   && rm -f timer ssltest parser uri_test test_https test_asio_curl
 
-COPY ./docker.drachtio.conf.xml /etc/drachtio.conf.xml
+VOLUME ["/config"]
+
 COPY ./entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Fixed issue with config file missing before COPY able to be executed. Added potential VOLUME mount for config files from external source.

Within the RUN there is a removal for the checked out repo directory, thereafter there is a COPY command which should have copied the docker.drachtio.conf.xml  to the /etc/ folder which fails due to the file no longer being in the path it is being copied from.

I added an entry for a VOLUME to be mounted if your config lives on persistent storage outside of the container. I currently use this with my kubernetes deployments to bundle up different storage volumes for production, staging and development. Might be a nice :smile: 

In my kubernetes deployment I have:

```
...
spec:
      containers:
      - image: drachtio/drachtio-server:latest
        name: drachtio-server
        command: 
          - drachtio
          - "-f /config/drachtio.conf.xml"
        volumeMounts:
          - name: config-storage
            mountPath: /config
      volumes:
        - name: config-storage
          hostPath: 
            path: /storage/drachtio-server-production
```