### PR TITLE
Building on OSX

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ test_asio_curl_SOURCES= src/test_asio_curl.cpp
 ttest_asio_curl_CPPFLAGS=-D_REENTRANT -DDEBUG -g -O0
 test_asio_curl_LDADD= ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_thread.a ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_system.a -lpthread -lcurl -lssl -lcrypto -lz
 
+
 if LINUX
 drachtio_LDADD += ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_thread.a ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_system.a ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_log.a ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_regex.a ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_filesystem.a -lpthread -lssl -lcrypto -lz -lrt
 timer_LDADD += -lrt
@@ -40,9 +41,9 @@ parser_LDADD += -lrt
 test_https_LDADD += -lrt -lpthread ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_system.a
 endif
 if OSX
-drachtio_LDADD += -lboost_thread -lboost_filesystem -lboost_system -lboost_regex -lboost_log
+drachtio_LDADD += ${srcdir}/deps/boost_1_63_0/stage/lib/libboost* -lpthread -lssl -lcrypto -lz 
 drachtio_CPPFLAGS += -DBOOST_LOG_DYN_LINK
-test_https_LDADD += -lboost_system
+test_https_LDADD += ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_system.a
 test_https_CPPFLAGS += -DBOOST_LOG_DYN_LINK
 endif
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -41,10 +41,10 @@ parser_LDADD += -lrt
 test_https_LDADD += -lrt -lpthread ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_system.a
 endif
 if OSX
-drachtio_LDADD += ${srcdir}/deps/boost_1_63_0/stage/lib/libboost* -lpthread -lssl -lcrypto -lz 
-drachtio_CPPFLAGS += -DBOOST_LOG_DYN_LINK
-test_https_LDADD += ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_system.a
-test_https_CPPFLAGS += -DBOOST_LOG_DYN_LINK
+drachtio_LDADD += -L/usr/local/opt/openssl/lib ${srcdir}/deps/boost_1_63_0/stage/lib/libboost* -lpthread -lssl -lcrypto -lz 
+drachtio_CPPFLAGS += -DBOOST_LOG_DYN_LINK -I/usr/local/opt/openssl/include
+test_https_LDADD += ${srcdir}/deps/boost_1_63_0/stage/lib/libboost_system.a -L/usr/local/opt/openssl/lib
+test_https_CPPFLAGS += -DBOOST_LOG_DYN_LINK -I/usr/local/opt/openssl/include
 endif
 
 BUILT_SOURCES=${srcdir}/deps/boost_1_63_0/stage/lib/libboost_thread.a ${srcdir}/deps/sofia-sip/libsofia-sip-ua/.libs/libsofia-sip-ua.a ${srcdir}/deps/jansson-2.10/src/.libs/libjansson.a

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An ansible role can be found [here](https://github.com/davehorton/ansible-role-d
 
 ## Building from source
 
-> Note: The build requires libcurl, which can be installed on debian as `sudo apt install libcurl4-openssl-dev`. All other third-party dependencies can be found under $(srcdir)/deps.  These include boost and the [sofia sip stack](https://github.com/davehorton/sofia-sip).  sofia is included as git submodules in this project.
+> Note: The build requires libcurl, which can be installed on debian as `sudo apt install libcurl4-openssl-dev`. All other third-party dependencies can be found under $(srcdir)/deps.  These include boost and the [sofia sip stack](https://github.com/davehorton/sofia-sip).  sofia is included as git submodules in this project. On OSX you need to run ``` brew install openssl ``` .
 
 After installing libcurl, do as follows:
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,22 @@ AC_CANONICAL_HOST
 case $host_os in
 *darwin* | *rhapsody* | *macosx*)
      AM_CONDITIONAL(OSX, true)
+		
+		 # thanks to bitcoin configure.ac
+		 AC_CHECK_PROG([BREW],brew, brew)
+		 if test x$BREW = xbrew; then
+			 dnl These Homebrew packages may be keg-only, meaning that they won't be found
+			 dnl in expected paths because they may conflict with system files. Ask
+			 dnl Homebrew where each one is located, then adjust paths accordingly.
+			 dnl It's safe to add these paths even if the functionality is disabled by
+			 dnl the user (--without-wallet or --without-gui for example).
+
+			 openssl_prefix=`$BREW --prefix openssl 2>/dev/null`
+			 if test x$openssl_prefix != x; then
+				 PKG_CONFIG_PATH="$openssl_prefix/lib/pkgconfig:$PKG_CONFIG_PATH"
+				 export PKG_CONFIG_PATH
+			 fi
+		 fi
      ;;
 *)
      AM_CONDITIONAL(LINUX, true)


### PR DESCRIPTION
Hi Dave, I'm trying to fix the OSX build issue and I have gotten it to build again using the sequence of command in the readme. As long as the user do ``` brew install openssl ``` first.

So this builds but I still get these things regarding boosts dynamic library when trying to run the binary
```
dyld: Library not loaded: libboost_log.dylib
  Referenced from: /usr/local/bin/drachtio
  Reason: image not found
```
right now if i just do this: 
``` find bin.v2/libs | grep .dylib | awk '{system("ln -s $PWD/" $1 " /usr/local/lib")}'``` (symlinking those dylibs to /usr/local/lib)
in the deps/boost folder that will take care of the above message and I think maybe make install boost will do it too

Should that just be chained in somewhere at the end? or there is actually another problem?

Cheers
Andrew

