### PR TITLE
Fixed issue with missing file entrypoint.sh on COPY line.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,12 @@ RUN apt-get update \
   && rm -Rf /var/lib/apt/lists/* \
   && cd /usr/local/src \
   && cp drachtio-server/docker.drachtio.conf.xml /etc/drachtio.conf.xml \
+  && cp drachtio-server/entrypoint.sh / \
   && rm -Rf drachtio-server \
   && cd /usr/local/bin \
   && rm -f timer ssltest parser uri_test test_https test_asio_curl
 
 VOLUME ["/config"]
-
-COPY ./entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
The entrypoint.sh file is deleted with the checked out source code in the RUN command so when it reached the COPY command it was no longer there anymore. I moved the copy to be part of the RUN command.