### PR TITLE
Fix use-after-free in SIP request method check.

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1194,9 +1194,10 @@ namespace drachtio {
                         if( status > 0  ) {
                             msg_t* reply = nta_msg_create(m_nta, 0) ;
                             msg_ref_create(reply) ;
+                            bool is_invite = sip->sip_request->rq_method == sip_method_invite;
                             nta_msg_mreply( m_nta, reply, sip_object(reply), status, NULL, msg, TAG_END() ) ;
 
-                            if( sip->sip_request->rq_method == sip_method_invite ) {
+                            if( is_invite ) {
                                 Cdr::postCdr( std::make_shared<CdrStop>( reply, "application", Cdr::call_rejected ) );
                             }
                             msg_destroy(reply) ;


### PR DESCRIPTION
This is a relatively straightforward and minor issue discovered by running Drachtio under ASAN. The `sip_request` object is freed along with the underlying `msg` when `nta_msg_mreply` is called. The fix is to check the method prior to replying.

This PR is based on the `nat-handling` branch; please check whether this needs to be ported to other branches and cherry-pick accordingly.

```
==21612==ERROR: AddressSanitizer: heap-use-after-free on address 0x6190000060c0 at pc 0x5595f012d218 bp 0x7ffe3e2dba90 sp 0x7ffe3e2dba80
READ of size 8 at 0x6190000060c0 thread T0
    #0 0x5595f012d217 in drachtio::DrachtioController::processMessageStatelessly(msg_s*, sip_s*) (/home/ubuntu/drachtio-server/build/drachtio+0x137217)

0x6190000060c0 is located 320 bytes inside of 936-byte region [0x619000005f80,0x619000006328)
freed by thread T0 here:
    #0 0x7f666e90c7b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
    #1 0x5595f05245aa in su_home_unref (/home/ubuntu/drachtio-server/build/drachtio+0x52e5aa)
    #2 0x5595f046e4ff in msg_destroy (/home/ubuntu/drachtio-server/build/drachtio+0x4784ff)
    #3 0x5595f04ab8e8 in mreply (/home/ubuntu/drachtio-server/build/drachtio+0x4b58e8)
    #4 0x5595f04aa410 in nta_msg_mreply (/home/ubuntu/drachtio-server/build/drachtio+0x4b4410)
    #5 0x5595f012d1eb in drachtio::DrachtioController::processMessageStatelessly(msg_s*, sip_s*) (/home/ubuntu/drachtio-server/build/drachtio+0x1371eb)

previously allocated by thread T0 here:
    #0 0x7f666e90cd38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x5595f05241a4 in su_home_new (/home/ubuntu/drachtio-server/build/drachtio+0x52e1a4)
    #2 0x5595f046df48 in msg_create (/home/ubuntu/drachtio-server/build/drachtio+0x477f48)
    #3 0x5595f04a80fc in nta_msg_create_for_transport (/home/ubuntu/drachtio-server/build/drachtio+0x4b20fc)
```