### PR TITLE
Added libtool-bin and cmake dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ The following libraries are required to build:
 * gcc and c++ compilers
 * libssl-dev
 * libtool
+* libtool-bin
 * autoconf
 * automake
+* cmake
 * zlib1g-dev
 
 ## Installing


### PR DESCRIPTION
Tried to install in Debian and make failed due to libtool-bin and cmake dependencies missing so I have updated the README.md file to reflect this